### PR TITLE
Adding new rule for arch test

### DIFF
--- a/amorphie.template.test/architecture/DependencyCheck.cs
+++ b/amorphie.template.test/architecture/DependencyCheck.cs
@@ -1,4 +1,5 @@
 using NetArchTest.Rules;
+using NetArchTest.Rules.Extensions;
 
 namespace amorphie.template.test;
 
@@ -18,5 +19,22 @@ public class DependencyCheck
 
             Assert.True(result);
             */
+    }
+
+    //core uygulamasının data ve application tarafına bağımlı olmaması clean code arch. açısından önemlidir. GErek duyulursa kullanılabilir
+    [Fact]
+    public void CoreShouldNotReferenceDataOrApplication()
+    {
+        var result = Types.InCurrentDomain()
+            .That()
+            .ResideInNamespace("amorphie.template.core")
+            .Should()
+            .NotHaveDependencyOn("amorphie.template.data")
+            .And()
+            .NotHaveDependencyOn("amorphie.template.application")
+            .GetResult()
+            .IsSuccessful;
+
+        Assert.True(result);
     }
 }


### PR DESCRIPTION
New rule is added to architecture DependencyCheck class. This rule checks if the amorphie.template.core namespace does not have any dependencies on the amorphie.template.data and amorphie.template.application namespaces.